### PR TITLE
Suppress error message when redirecting to login after unsuccessful auth

### DIFF
--- a/packages/ra-auth-msal/src/authProvider.ts
+++ b/packages/ra-auth-msal/src/authProvider.ts
@@ -131,8 +131,12 @@ export const msalAuthProvider = ({
       if (!account || !token) {
         if (redirectOnCheckAuth) {
           msalInstance.loginRedirect(loginRequest);
+          
+          // Suppresses error message from being displayed
+          throw { message: false };
+        } else {
+          throw new Error("Unauthorized");
         }
-        throw new Error("Unauthorized");
       }
     },
 


### PR DESCRIPTION
Fixes showing an error notification when the user's session is not authenticated, the user must login, and a redirect request is made. Fixes #5