### PR TITLE
Fix infinite redirect on Login page

### DIFF
--- a/packages/ra-auth-msal/src/authProvider.ts
+++ b/packages/ra-auth-msal/src/authProvider.ts
@@ -70,11 +70,11 @@ const MSAL_REDIRECT_KEY = "_ra_msal_redirect_key";
  *       setMSALInitialized(true);
  *     });
  *   }, []);
- * 
+ *
  *   const authProvider = msalAuthProvider({
  *     msalInstance: myMSALObj,
  *   });
- * 
+ *
  *   if (!isMSALInitialized) {
  *     return <div>Loading...</div>;
  *   }
@@ -102,10 +102,10 @@ export const msalAuthProvider = ({
   redirectOnCheckAuth = true,
   enableDeepLinkRedirect = true,
 }: MsalAuthProviderParams): AuthProvider => {
-  // We need to invoke handleRedirectPromise when the application uses redirect flows. 
+  // We need to invoke handleRedirectPromise when the application uses redirect flows.
   // When using redirect flows, handleRedirectPromise should be run on every page load.
   // https://learn.microsoft.com/en-us/entra/identity-platform/msal-js-initializing-client-applications#handleredirectpromise
-  
+
   const canDeepLinkRedirect =
     enableDeepLinkRedirect &&
     typeof window != undefined &&
@@ -117,7 +117,9 @@ export const msalAuthProvider = ({
       if (canDeepLinkRedirect) {
         // We cannot use react-router location here, as we are not in a router context,
         // So we need to fallback to native browser APIs.
-        sessionStorage.setItem(MSAL_REDIRECT_KEY, window.location.href);
+        if (!sessionStorage.getItem(MSAL_REDIRECT_KEY)) {
+          sessionStorage.setItem(MSAL_REDIRECT_KEY, window.location.href);
+        }
       }
 
       // Used when the redirection to the MS login form is done from a custom login page


### PR DESCRIPTION
## Problem

Probably consecutive to [Update to ](https://github.com/marmelab/ra-auth-msal/pull/15 "‌")`@azure/msal-browser`[ v3](https://github.com/marmelab/ra-auth-msal/pull/15 "‌")

The **DeepLinkRedirect** feature is broken.

I.e. if you browse to [http://localhost:8080/comments/1/show](http://localhost:8080/comments/1/show "‌"), after sign in, you will be redirected to a (broken) [http://localhost:8080/login](http://localhost:8080/login "‌") page (it will be loading forever).

However if you try to access [http://localhost:8080/](http://localhost:8080/ "‌") instead, it will work fine and redirect to [http://localhost:8080/posts](http://localhost:8080/posts "‌").